### PR TITLE
fix: make serial mode consistent with parallel

### DIFF
--- a/lib/repeater.js
+++ b/lib/repeater.js
@@ -35,7 +35,8 @@ module.exports = class TestRepeater {
     handleTestEnd(test) {
         this._repeatCounter.testExecuted(test);
 
-        if (!this._parallelRepeats && this._repeatCounter.getRepeatsLeft(test) > 0) {
+        // In parallel mode, we always have 1 (initial run) + repeats test runs. We have + 1 here to account for that initial run
+        if (!this._parallelRepeats && this._repeatCounter.getRepeatsLeft(test) + 1 > 0) {
             this._testplane.addTestToRun(test, test.browserId);
         }
     }

--- a/test/lib/repeater.js
+++ b/test/lib/repeater.js
@@ -94,7 +94,8 @@ describe('Repeater', () => {
 
         it('should not add test to run when parallelRepeats is false and test has no repeats left', () => {
             const repeatCounter = _mkRepeatCounter();
-            repeatCounter.getRepeatsLeft = sinon.stub().returns(0);
+            // If repeats are set 0 and parallelRepeats is false, getRepeatsLeft would return -1 at runtime
+            repeatCounter.getRepeatsLeft = sinon.stub().returns(-1);
             const repeater = Repeater.create(testplane, repeatCounter, false);
             const test = _mkTest();
 


### PR DESCRIPTION
Without this fix, there are several issues with serial repeats mode:
- Exit code can be incorrectly 0, because we override last fail status with retry, which is not considered a failure in the end
- In serial mode we have one retry less, compared to parallel mode, which is inconsistent